### PR TITLE
feat: Implement undetectable YouTube ad skipping

### DIFF
--- a/youtubeControl.js
+++ b/youtubeControl.js
@@ -1,9 +1,101 @@
+// 페이지 컨텍스트에 주입될 핵심 광고 스킵 로직
+function injectedScript() {
+  console.log('[YT Ad Skipper] 주입된 스크립트 실행 중.');
+
+  let wasAdPlaying = false;
+  // 광고 이후 비디오 상태를 복원하기 위해 원래 상태를 저장합니다.
+  let originalVideoState = {
+    muted: false,
+    playbackRate: 1.0,
+  };
+
+  const adSkipper = () => {
+    // 1. 애드블록 방지 팝업 처리
+    const adblockWarning = document.querySelector('ytd-enforcement-message-view-model, [class*="enforcement-message"]');
+    if (adblockWarning && adblockWarning.offsetParent !== null) {
+      console.log('[YT Ad Skipper] 애드블록 방지 메시지를 발견하여 제거합니다.');
+      adblockWarning.remove();
+      const video = document.querySelector('video');
+      if (video && video.paused) {
+        video.play(); // 비디오 강제 재생
+      }
+      return; // 차단기 제거를 우선 처리
+    }
+
+    // 2. 광고 처리
+    const player = document.querySelector('#movie_player');
+    const isAd = player && player.classList.contains('ad-showing');
+
+    if (isAd) {
+      // 현재 광고가 표시되고 있습니다.
+      const video = document.querySelector('video');
+      if (!wasAdPlaying && video) {
+        // 광고가 막 시작되었으므로 비디오 상태를 저장합니다.
+        originalVideoState.muted = video.muted;
+        originalVideoState.playbackRate = video.playbackRate;
+        console.log('[YT Ad Skipper] 광고 시작. 비디오 상태 저장됨:', originalVideoState);
+      }
+      wasAdPlaying = true;
+
+      // 먼저 건너뛰기 버튼을 클릭합니다.
+      const skipButton = document.querySelector('.ytp-ad-skip-button, .ytp-ad-skip-button-modern');
+      if (skipButton && skipButton.offsetParent !== null) {
+        console.log('[YT Ad Skipper] 건너뛰기 버튼 클릭.');
+        skipButton.click();
+        return;
+      }
+
+      // 건너뛰기 버튼이 없다면, 건너뛸 수 없는 광고입니다. 음소거하고 숨깁니다.
+      if (video) {
+        video.muted = true;
+        // 감지될 수 있는 빨리 감기 대신, 광고 컨테이너를 숨깁니다.
+        if (player) player.style.visibility = 'hidden';
+      }
+    } else if (wasAdPlaying) {
+      // 광고가 방금 끝났습니다. 비디오 상태를 복원합니다.
+      console.log('[YT Ad Skipper] 광고 종료. 비디오 상태를 복원합니다.');
+      const video = document.querySelector('video');
+      if (video) {
+        video.muted = originalVideoState.muted;
+        video.playbackRate = originalVideoState.playbackRate;
+        if (player) player.style.visibility = 'visible';
+      }
+      wasAdPlaying = false;
+    }
+  };
+
+  // 주기적으로 스키퍼를 실행합니다.
+  setInterval(adSkipper, 300); // 더 빠른 감지를 위해 300ms로 설정
+}
+
+
 class YoutubeController {
   constructor() {
     this.skipTime = 5; // 기본값 5초
-    this.isProcessing = false; // 중복 실행 방지
     this.initializeState();
-    this.setupControls();
+    this.setupControls(); // UI 버튼 설정
+    this.injectScript(); // 핵심 로직 주입
+  }
+
+  // 페이지에 광고 스킵 스크립트를 주입하는 함수
+  injectScript() {
+    try {
+      const scriptId = 'yt-ad-skipper-script';
+      // 이미 주입된 스크립트가 있다면 중복 실행 방지
+      if (document.getElementById(scriptId)) return;
+
+      const script = document.createElement('script');
+      script.id = scriptId;
+      // 함수를 즉시 실행되는 함수 표현식(IIFE)으로 감싸서 주입
+      script.textContent = `(${injectedScript.toString()})();`;
+
+      (document.head || document.documentElement).appendChild(script);
+      // 주입 후 DOM에서 스크립트 태그 정리
+      script.remove();
+      console.log('광고 스킵 스크립트가 페이지에 성공적으로 주입되었습니다.');
+    } catch (e) {
+      console.error('스크립트 주입 실패:', e);
+    }
   }
 
   async initializeState() {
@@ -15,8 +107,8 @@ class YoutubeController {
     }
   }
 
+  // UI 관련 설정은 그대로 유지
   setupControls() {
-    // 기존 버튼들 먼저 제거
     this.removeExistingButtons();
     
     const checkForPlayer = setInterval(() => {
@@ -24,20 +116,16 @@ class YoutubeController {
       if (player) {
         clearInterval(checkForPlayer);
         this.createButtons(player);
-        this.createUtilityButtons(player);
       }
     }, 1000);
   }
 
   createButtons(player) {
-    // 재생 버튼 옆의 컨트롤 영역 찾기
     const leftControls = player.querySelector('.ytp-left-controls');
     if (!leftControls) return;
 
-    // 기존 커스텀 버튼들 제거 (중복 방지)
     this.removeExistingButtons();
 
-    // 재생 버튼 다음 위치 찾기
     const playButton = leftControls.querySelector('.ytp-play-button');
     if (!playButton) return;
 
@@ -50,7 +138,6 @@ class YoutubeController {
       filter: drop-shadow(0 1px 1px rgba(0,0,0,0.5));
     `;
 
-    // 재생 버튼을 복제해서 아이콘만 변경
     const backwardButton = playButton.cloneNode(true);
     backwardButton.className = 'ytp-button ytp-custom-backward-button';
     backwardButton.innerHTML = `
@@ -58,11 +145,7 @@ class YoutubeController {
         <path d="M21,7L12,12l9,5V7z M11,7v10l-9-5L11,7z"/>
       </svg>
     `;
-    // 기본 스타일은 유지하고 필요한 부분만 수정
-    Object.assign(backwardButton.style, {
-      margin: '0 2px',
-      opacity: '0.9'
-    });
+    Object.assign(backwardButton.style, { margin: '0 2px', opacity: '0.9' });
     backwardButton.title = `${this.skipTime}초 뒤로`;
     backwardButton.onclick = () => this.skip(-this.skipTime);
 
@@ -73,26 +156,16 @@ class YoutubeController {
         <path d="M3,7v10l9-5L3,7z M13,7v10l9-5L13,7z"/>
       </svg>
     `;
-    // 기본 스타일은 유지하고 필요한 부분만 수정
-    Object.assign(forwardButton.style, {
-      margin: '0 2px',
-      opacity: '0.9'
-    });
+    Object.assign(forwardButton.style, { margin: '0 2px', opacity: '0.9' });
     forwardButton.title = `${this.skipTime}초 앞으로`;
     forwardButton.onclick = () => this.skip(this.skipTime);
 
-    // 재생 버튼 다음에 삽입
     playButton.insertAdjacentElement('afterend', forwardButton);
     playButton.insertAdjacentElement('afterend', backwardButton);
 
-    // 마우스 이벤트 핸들러 수정
     [backwardButton, forwardButton].forEach(button => {
-      button.addEventListener('mouseover', () => {
-        button.style.opacity = '1';
-      });
-      button.addEventListener('mouseout', () => {
-        button.style.opacity = '0.9';
-      });
+      button.addEventListener('mouseover', () => { button.style.opacity = '1'; });
+      button.addEventListener('mouseout', () => { button.style.opacity = '0.9'; });
     });
   }
 
@@ -103,404 +176,14 @@ class YoutubeController {
     }
   }
 
-  // 광고 감지 함수 (정확한 감지만)
-  isAdPlaying() {
-    // 1. 가장 확실한 광고 표시 - 플레이어에 ad-showing 클래스
-    const player = document.querySelector('#movie_player');
-    if (player && player.classList.contains('ad-showing')) {
-      console.log('🎯 광고 감지: ad-showing 클래스');
-      return true;
-    }
-
-    // 2. 광고 스킵 버튼이 보이는 경우 (가장 확실한 광고 신호)
-    const skipButton = document.querySelector('.ytp-ad-skip-button, .ytp-skip-ad-button');
-    if (skipButton && skipButton.offsetParent !== null && skipButton.style.display !== 'none') {
-      console.log('🎯 광고 감지: 스킵 버튼 존재');
-      return true;
-    }
-
-    // 3. 광고 시간 표시가 보이는 경우
-    const adTime = document.querySelector('.ytp-ad-duration-remaining');
-    if (adTime && adTime.offsetParent !== null && adTime.style.display !== 'none') {
-      console.log('🎯 광고 감지: 광고 시간 표시');
-      return true;
-    }
-
-    // 4. 광고 오버레이가 보이는 경우
-    const adOverlay = document.querySelector('.ytp-ad-player-overlay');
-    if (adOverlay && adOverlay.offsetParent !== null && adOverlay.style.display !== 'none') {
-      console.log('🎯 광고 감지: 광고 오버레이');
-      return true;
-    }
-
-    // 5. 광고 텍스트가 보이는 경우
-    const adText = document.querySelector('.ytp-ad-text');
-    if (adText && adText.offsetParent !== null && adText.style.display !== 'none') {
-      console.log('🎯 광고 감지: 광고 텍스트');
-      return true;
-    }
-
-    // 6. 명확한 광고 URL 패턴만 확인 (매우 제한적으로)
-    const video = document.querySelector('video');
-    if (video && video.currentSrc) {
-      // 확실한 광고 서버만 확인
-      if (video.currentSrc.includes('doubleclick.net') || 
-          video.currentSrc.includes('googleadservices.com') ||
-          video.currentSrc.includes('googlesyndication.com')) {
-        console.log('🎯 광고 감지: 광고 서버 URL');
-        return true;
-      }
-    }
-
-    return false;
-  }
-
-  // 광고 감지 디버깅 함수
-  debugAdDetection() {
-    console.log('🔍 광고 감지 상태 확인:');
-    
-    const player = document.querySelector('#movie_player');
-    console.log('- 플레이어 ad-showing 클래스:', player?.classList.contains('ad-showing') || false);
-    
-    const skipButton = document.querySelector('.ytp-ad-skip-button, .ytp-skip-ad-button');
-    console.log('- 스킵 버튼 존재:', !!skipButton && skipButton.offsetParent !== null);
-    
-    const adTime = document.querySelector('.ytp-ad-duration-remaining');
-    console.log('- 광고 시간 표시:', !!adTime && adTime.offsetParent !== null);
-    
-    const adOverlay = document.querySelector('.ytp-ad-player-overlay');
-    console.log('- 광고 오버레이:', !!adOverlay && adOverlay.offsetParent !== null);
-    
-    const adText = document.querySelector('.ytp-ad-text');
-    console.log('- 광고 텍스트:', !!adText && adText.offsetParent !== null);
-    
-    const video = document.querySelector('video');
-    if (video && video.currentSrc) {
-      console.log('- 비디오 URL:', video.currentSrc.substring(0, 100) + '...');
-      console.log('- 광고 서버 URL 포함:', 
-        video.currentSrc.includes('doubleclick.net') ||
-        video.currentSrc.includes('googleadservices.com') ||
-        video.currentSrc.includes('googlesyndication.com')
-      );
-    }
-  }
-
-  // 광고 차단 경고 화면 감지 함수 (디버깅 포함)
-  isAdBlockWarningShown() {
-    // 경고 메시지 관련 선택자들
-    const warningSelectors = [
-      'ytd-enforcement-message-view-model',
-      '[class*="enforcement-message"]',
-      '[class*="playability-error"]',
-      '.yt-playability-error-supported-renderers'
-    ];
-
-    for (const selector of warningSelectors) {
-      const element = document.querySelector(selector);
-      if (element && element.offsetParent !== null) {
-        // 텍스트 내용도 확인
-        const text = element.textContent || '';
-        if (text.includes('광고 차단') || 
-            text.includes('ad block') || 
-            text.includes('YouTube 서비스 약관') ||
-            text.includes('광고를 기반으로')) {
-          console.log('🚨 경고 화면 감지 (DOM 요소):', selector);
-          console.log('📝 감지된 텍스트:', text.substring(0, 100) + '...');
-          return true;
-        }
-      }
-    }
-
-    // 특정 텍스트 패턴으로도 확인 (더 제한적으로)
-    const warningTexts = [
-      '광고 차단 프로그램을 사용 중인 것 같습니다',
-      'YouTube 서비스 약관을 위반하는',
-      'ad blocker'
-    ];
-
-    // body 전체 텍스트 확인은 너무 광범위할 수 있으므로 제거하고
-    // 특정 컨테이너만 확인
-    const mainContainer = document.querySelector('#player-container, #movie_player, .html5-video-container');
-    if (mainContainer) {
-      const containerText = mainContainer.textContent || '';
-      for (const warningText of warningTexts) {
-        if (containerText.includes(warningText)) {
-          console.log('🚨 경고 화면 감지 (텍스트 패턴):', warningText);
-          return true;
-        }
-      }
-    }
-
-    return false;
-  }
-
-
-  // 스킵 완료 후 경고화면 확인 (한 번만)
-  checkWarningAfterSkip() {
-    console.log('🔍 스킵 완료 후 경고화면 확인...');
-    
-    if (this.isAdBlockWarningShown()) {
-      console.log('⚠️ 광고 스킵 후 경고 화면이 감지되었습니다. 즉시 새로고침...');
-      console.log('🔄 경고 화면으로 인한 페이지 새로고침 실행');
-      window.location.reload();
-    } else {
-      console.log('✅ 경고화면 없음 - 정상 상태');
-    }
-  }
-
-  // 광고 끝나기 3초 전으로 이동하는 함수 (광고일 때만 작동)
-  jumpToEnd() {
-    if (this.isProcessing) return;
-
-    // 1. 광고 재생 중이 아니면 아무것도 하지 않음
-    if (!this.isAdPlaying()) return;
-
-    this.isProcessing = true;
-
-    // 2. 건너뛰기 버튼이 있으면 즉시 클릭 (가장 안전한 방법)
-    if (this.clickSkipButton()) {
-      console.log('✅ "광고 건너뛰기" 버튼을 클릭했습니다.');
-      this.isProcessing = false;
-      return;
-    }
-
-    // 3. 건너뛸 수 없는 광고 처리: 음소거 및 최대 배속
-    const video = document.querySelector('video');
-    if (video) {
-      console.log('🔇 건너뛸 수 없는 광고입니다. 음소거 및 최대 배속으로 재생합니다.');
-      video.muted = true;
-      video.playbackRate = 16;
-    }
-
-    // 잠시 후 처리 상태 해제
-    setTimeout(() => {
-      this.isProcessing = false;
-    }, 1000);
-  }
-
-
-  // 유튜브 건너뛰기 버튼 표시 여부 확인 (더욱 강화된 버전)
-  isYouTubeSkipButtonVisible() {
-    const skipButtonSelectors = [
-      '.ytp-ad-skip-button-modern',   // 최신 UI 스킵 버튼
-      '.ytp-skip-ad-button',          // 클래식 스킵 버튼
-      '.ytp-ad-skip-button',          // 이전 스킵 버튼
-      'button[id*="skip-button"]',    // ID에 'skip-button'을 포함하는 버튼
-      '.ytp-ad-skip-button-slot',     // 스킵 버튼을 담는 컨테이너
-      'yt-button-renderer[id*="skip"]', // YouTube 웹 컴포넌트 기반 버튼
-    ];
-
-    for (const selector of skipButtonSelectors) {
-      const skipButton = document.querySelector(selector);
-      
-      // 버튼이 존재하고, 화면에 보이며(offsetParent), 비활성화 상태가 아닐 때
-      if (skipButton && 
-          skipButton.offsetParent !== null && 
-          !skipButton.disabled) {
-        
-        // 버튼이 실제로 클릭 가능한지 확인 (너비와 높이가 0보다 큼)
-        const rect = skipButton.getBoundingClientRect();
-        if (rect.width > 0 && rect.height > 0) {
-          console.log(`🔍 건너뛰기 버튼 (표시됨) 감지: ${selector}`);
-          return true;
-        }
-      }
-    }
-    
-    return false;
-  }
-
-  // 페이지 새로고침 함수
-  refreshPage() {
-    window.location.reload();
-  }
-
-  // 유틸리티 버튼들 생성 (광고스킵)
-  createUtilityButtons(player) {
-    const leftControls = player.querySelector('.ytp-left-controls');
-    if (!leftControls) return;
-
-    const buttonStyle = `
-      display: inline-flex !important;
-      align-items: center !important;
-      justify-content: center !important;
-      padding: 0 8px !important;
-      margin: 0 4px !important;
-      font-size: 13px !important;
-      color: #fff !important;
-      background-color: transparent !important;
-      border: none !important;
-      border-radius: 2px !important;
-      cursor: pointer !important;
-      white-space: nowrap !important;
-      height: 46px !important;
-      min-width: auto !important;
-      font-weight: 500 !important;
-      opacity: 1 !important;
-      visibility: visible !important;
-      position: relative !important;
-      z-index: 10 !important;
-      flex-shrink: 0 !important;
-    `;
-
-    // 광고 스킵 버튼 생성 (하나만)
-    const jumpButton = document.createElement('button');
-    jumpButton.className = 'ytp-button ytp-custom-jump-button';
-    jumpButton.title = '광고일 때만: 광고 끝나기 3초 전으로 이동';
-    jumpButton.style.cssText = buttonStyle;
-    jumpButton.textContent = '광고스킵';
-    jumpButton.addEventListener('click', () => this.jumpToEnd());
-
-    // 호버 효과 추가
-    jumpButton.addEventListener('mouseenter', () => {
-      jumpButton.style.backgroundColor = 'rgba(255, 255, 255, 0.1)';
-    });
-    jumpButton.addEventListener('mouseleave', () => {
-      jumpButton.style.backgroundColor = 'transparent';
-    });
-
-    // 버튼 배치 - 음소거 버튼 앞에 배치
-    const muteButton = leftControls.querySelector('.ytp-mute-button');
-    if (muteButton) {
-      muteButton.insertAdjacentElement('beforebegin', jumpButton);
-      return;
-    }
-
-    // 볼륨 패널 앞에 배치
-    const volumePanel = leftControls.querySelector('.ytp-volume-panel');
-    if (volumePanel) {
-      volumePanel.insertAdjacentElement('beforebegin', jumpButton);
-      return;
-    }
-
-    // 시간 표시 앞에 배치
-    const timeDisplay = leftControls.querySelector('.ytp-time-display');
-    if (timeDisplay) {
-      timeDisplay.insertAdjacentElement('beforebegin', jumpButton);
-      return;
-    }
-
-    // 마지막: 왼쪽 컨트롤 맨 뒤에 추가
-    leftControls.appendChild(jumpButton);
-  }
-
-  // 기존 커스텀 버튼들 제거 (모든 커스텀 버튼)
   removeExistingButtons() {
-    document.querySelectorAll('.ytp-custom-backward-button, .ytp-custom-forward-button, .ytp-custom-jump-button').forEach(button => {
+    document.querySelectorAll('.ytp-custom-backward-button, .ytp-custom-forward-button').forEach(button => {
       button.remove();
     });
   }
 
-  // 기존 유틸리티 버튼들 제거 (호환성을 위해 유지)
-  removeExistingUtilityButtons() {
-    this.removeExistingButtons();
-  }
-
-
-  // 자동 광고 스킵 기능 (선택적)
-  enableAutoSkip() {
-    if (this.autoSkipInterval) {
-      clearInterval(this.autoSkipInterval);
-    }
-
-    let wasAdPlaying = false;
-
-    // 1초마다 광고 및 경고 화면 확인
-    this.autoSkipInterval = setInterval(() => {
-      const isCurrentlyAd = this.isAdPlaying();
-
-      // 1. 경고 화면이 최우선 처리 대상
-      if (this.handleAntiAdblock()) {
-        return;
-      }
-
-      // 2. 광고 스킵 로직
-      if (isCurrentlyAd && !this.isProcessing) {
-        console.log('🤖 자동 광고 스킵 실행');
-        this.jumpToEnd();
-        wasAdPlaying = true;
-      }
-      // 3. 광고가 끝난 직후 원래 상태로 복구
-      else if (wasAdPlaying && !isCurrentlyAd) {
-        const video = document.querySelector('video');
-        if (video) {
-          console.log('🎬 광고가 종료되었습니다. 원래 재생 상태로 복구합니다.');
-          video.muted = false;
-          video.playbackRate = 1.0;
-        }
-        wasAdPlaying = false;
-      }
-    }, 1000);
-  }
-
-  // 자동 스킵 비활성화
-  disableAutoSkip() {
-    if (this.autoSkipInterval) {
-      clearInterval(this.autoSkipInterval);
-      this.autoSkipInterval = null;
-    }
-  }
-
-  // 클래스 정리 (메모리 누수 방지)
-  handleAntiAdblock() {
-    const warningSelector = 'ytd-enforcement-message-view-model, [class*="enforcement-message"]';
-    const warningElement = document.querySelector(warningSelector);
-
-    if (warningElement && warningElement.offsetParent !== null) {
-      console.log('🚫 광고 차단 경고 화면을 감지했습니다. 복구를 시도합니다.');
-
-      // 1. '닫기' 버튼이 있으면 클릭
-      const closeButton = warningElement.querySelector('yt-button-renderer#dismiss-button, button.ytp-button');
-      if (closeButton) {
-        console.log('Attempting to click the close button.');
-        closeButton.click();
-      }
-
-      // 2. 경고 화면 강제 제거
-      console.log('Removing the adblock warning element from the DOM.');
-      warningElement.remove();
-
-      // 3. 비디오 강제 재생
-      const video = document.querySelector('video');
-      if (video && video.paused) {
-        console.log('Video is paused, attempting to play.');
-        video.play();
-      }
-      return true;
-    }
-    return false;
-  }
-
-  clickSkipButton() {
-    const skipButtonSelectors = [
-      '.ytp-ad-skip-button-modern', // 최신 UI 스킵 버튼
-      '.ytp-skip-ad-button',      // 클래식 스킵 버튼
-      '.ytp-ad-skip-button',      // 이전 스킵 버튼
-      'button[class*="skip"]',    // 'skip'을 포함하는 모든 버튼
-    ];
-
-    for (const selector of skipButtonSelectors) {
-      const skipButton = document.querySelector(selector);
-      // 버튼이 존재하고, 화면에 보이며, 비활성화 상태가 아닐 때
-      if (skipButton && skipButton.offsetParent !== null && !skipButton.disabled) {
-        console.log(`✅ 건너뛰기 버튼 감지 및 클릭: ${selector}`);
-        skipButton.click(); // 버튼 클릭
-        return true; // 클릭 성공 시 true 반환
-      }
-    }
-    return false; // 적절한 버튼을 찾지 못함
-  }
-
   destroy() {
-    // 자동 스킵 인터벌 정리
-    if (this.autoSkipInterval) {
-      clearInterval(this.autoSkipInterval);
-      this.autoSkipInterval = null;
-    }
-
-    // 커스텀 버튼들 제거
     this.removeExistingButtons();
-    
     console.log('YoutubeController 정리 완료');
   }
 }


### PR DESCRIPTION
This change introduces a new method for skipping YouTube ads that is designed to be undetectable by YouTube's anti-adblocker mechanisms.

The previous method of controlling the video player from a content script was being detected by YouTube, resulting in the display of anti-adblocker warnings.

The new approach injects the ad-skipping logic directly into the page's context via a dynamically created `<script>` tag. This makes the script's actions appear native to the YouTube page, and therefore less likely to be detected.

The injected script will:
- Click the "Skip Ad" button if available.
- For unskippable ads, mute the video and hide the player container.
- Remove any anti-adblock warning popups from the DOM and force the video to resume playing.
- Restore the video's original mute state and visibility after an ad finishes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Injects an in-page ad-skipping script (skip/mute/hide/restore) and simplifies YoutubeController by removing legacy detection/auto-skip and utility buttons while retaining basic seek controls.
> 
> - **In-page ad skipper (injected)**:
>   - Injects `injectedScript()` via a `<script>` tag to run in page context every 300ms.
>   - Handles anti-adblock popups (removes element, resumes video).
>   - On ads: clicks skip when available; otherwise mutes video and hides `#movie_player`; restores `muted`/`playbackRate` and visibility after ads.
> - **Controller/UI changes** (`youtubeControl.js`):
>   - Adds `injectScript()` and calls it in constructor; removes `isProcessing`, auto-skip timers, and all ad-detection/debug/refresh helpers.
>   - Removes the "광고스킵" utility button and related creation/removal methods; keeps only forward/backward seek buttons.
>   - Simplifies cleanup to only remove custom seek buttons.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 72c3569412a04050df1169d6da58d195276d4d8d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->